### PR TITLE
Update language.xml

### DIFF
--- a/language.xml
+++ b/language.xml
@@ -3,4 +3,5 @@
     <code>sk_SK</code>
     <vendor>mageplaza</vendor>
     <package>sk_sk</package>
+    <use vendor="mageplaza" package="cs_cz"/>
 </language>


### PR DESCRIPTION
The translation into Czech is much more complete than the translation into Slovak.  The two languages are very similar, partly identical, and it is therefore advisable to display expressions not translated into Slovak in Czech rather than in English.